### PR TITLE
fix(db): drop storage trigger blocking account deletion

### DIFF
--- a/src/app/api/auth/delete-account/route.ts
+++ b/src/app/api/auth/delete-account/route.ts
@@ -2,6 +2,23 @@ import { createClient } from '@/libs/supabase/server';
 import { createAdminClient } from '@/libs/supabase/admin';
 import { NextResponse } from 'next/server';
 
+/**
+ * Clean up storage objects for a user before account deletion.
+ * Must use the Storage API — direct SQL DELETE on storage.objects
+ * is blocked by Supabase ("Direct deletion from storage tables is not allowed").
+ */
+async function cleanupUserStorage(admin: ReturnType<typeof createAdminClient>, userId: string) {
+  // Delete avatar
+  await admin.storage.from('avatars').remove([`${userId}.webp`]);
+
+  // Delete all product images (stored under {user_id}/ folder)
+  const { data: productImages } = await admin.storage.from('product-images').list(userId);
+  if (productImages && productImages.length > 0) {
+    const paths = productImages.map((file) => `${userId}/${file.name}`);
+    await admin.storage.from('product-images').remove(paths);
+  }
+}
+
 export async function DELETE() {
   try {
     const supabase = await createClient();
@@ -14,6 +31,14 @@ export async function DELETE() {
     }
 
     const admin = createAdminClient();
+
+    // Clean up storage before deleting the user (best-effort)
+    try {
+      await cleanupUserStorage(admin, user.id);
+    } catch (storageError) {
+      console.error('Storage cleanup error (non-blocking):', storageError);
+    }
+
     const { error } = await admin.auth.admin.deleteUser(user.id);
 
     if (error) {

--- a/supabase/migrations/20260321000000_fix_account_deletion_storage_trigger.sql
+++ b/supabase/migrations/20260321000000_fix_account_deletion_storage_trigger.sql
@@ -1,0 +1,20 @@
+-- ============================================================
+-- Migration: fix_account_deletion_storage_trigger
+-- Created: 2026-03-21
+-- Fixes:
+--   handle_profile_deletion() trigger tried to DELETE directly
+--   from storage.objects, which Supabase blocks with:
+--   "Direct deletion from storage tables is not allowed."
+--   This caused the entire auth.users DELETE cascade to roll back,
+--   making account deletion impossible.
+--
+-- Solution: Drop the trigger. Storage cleanup is now handled
+--   in the API route via the Supabase Storage API before
+--   calling deleteUser().
+-- ============================================================
+
+-- Drop the trigger that blocks account deletion
+DROP TRIGGER IF EXISTS on_profile_deleted ON public.members;
+
+-- Drop the function (no longer needed)
+DROP FUNCTION IF EXISTS public.handle_profile_deletion();


### PR DESCRIPTION
## Summary
- **Root cause:** `handle_profile_deletion()` trigger tried to `DELETE FROM storage.objects` directly, which Supabase blocks with "Direct deletion from storage tables is not allowed." This rolled back the entire `auth.users` CASCADE chain, making account deletion impossible.
- Dropped the broken trigger via migration (already applied to live DB)
- Moved storage cleanup to the delete-account API route using the Supabase Storage API (best-effort, non-blocking)

## Test plan
- [ ] Delete a test account from the dashboard — should succeed without 500 error
- [ ] Verify avatar is removed from Supabase Storage after deletion
- [ ] Clean up orphaned avatar `9db3006e-58fb-4e4a-8442-272756a87b18.webp` from avatars bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)